### PR TITLE
feat: AI chat integration with tool use, timezone support, and habit tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules/
 dist/
 dist-ssr/
 *.local
+/.claude/settings.local.json

--- a/StarList-Backend/app/src/main/java/app/config/OpenAiConfig.java
+++ b/StarList-Backend/app/src/main/java/app/config/OpenAiConfig.java
@@ -1,0 +1,25 @@
+package app.config;
+
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAiConfig {
+
+    @Value("${openai.api-key}")
+    private String apiKey;
+
+    /**
+     * Provides a singleton {@link OpenAIClient} configured with the API key from environment.
+     * The OkHttp client is thread-safe and reusable across requests.
+     */
+    @Bean
+    public OpenAIClient openAIClient() {
+        return OpenAIOkHttpClient.builder()
+                .apiKey(apiKey)
+                .build();
+    }
+}

--- a/StarList-Backend/app/src/main/resources/application-dev.yml
+++ b/StarList-Backend/app/src/main/resources/application-dev.yml
@@ -9,12 +9,6 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: https://cognito-idp.us-east-1.amazonaws.com/us-east-1_WBlndOjnO
-
-openai:
-  api-key: ${OPENAI_API_KEY}
-  model: gpt-4o-mini
-
-spring:
   jpa:
     hibernate:
       database-platform: org.hibernate.dialect.PostgreSQLDialect
@@ -29,4 +23,8 @@ spring:
       level:
         org.hibernate.SQL: DEBUG
         org.hibernate.orm.jdbc.bind: TRACE
+
+openai:
+  api-key: ${OPENAI_API_KEY}
+  model: gpt-4o-mini
 

--- a/StarList-Backend/app/src/main/resources/application-dev.yml
+++ b/StarList-Backend/app/src/main/resources/application-dev.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${AWS_DB_URL}
-    username: ${AWS_DB_USERNAME}
-    password: ${AWS_DB_PASSWORD}
+    url: jdbc:postgresql://localhost:5431/starlist
+    username: postgres
+    password: postgres
     driver-class-name: org.postgresql.Driver
   security:
     oauth2:
@@ -10,21 +10,22 @@ spring:
         jwt:
           issuer-uri: https://cognito-idp.us-east-1.amazonaws.com/us-east-1_WBlndOjnO
   jpa:
-    hibernate:
       database-platform: org.hibernate.dialect.PostgreSQLDialect
-      ddl-auto: update
-    show-sql: false # use logback SQL logger below instead (formats output better)
-    properties:
       hibernate:
-        jdbc:
-          time_zone: UTC
-        format_sql: true
-    logging:
-      level:
-        org.hibernate.SQL: DEBUG
-        org.hibernate.orm.jdbc.bind: TRACE
+        ddl-auto: update
+      show-sql: false # use logback SQL logger below instead (formats output better)
+      properties:
+        hibernate:
+          jdbc:
+            time_zone: UTC
+          format_sql: true
+      logging:
+        level:
+          org.hibernate.SQL: DEBUG
+          org.hibernate.orm.jdbc.bind: TRACE
 
 openai:
   api-key: ${OPENAI_API_KEY}
-  model: gpt-4o-mini
+  model: gpt-4.1-mini
+
 

--- a/StarList-Backend/app/src/main/resources/application-dev.yml
+++ b/StarList-Backend/app/src/main/resources/application-dev.yml
@@ -10,6 +10,11 @@ spring:
         jwt:
           issuer-uri: https://cognito-idp.us-east-1.amazonaws.com/us-east-1_WBlndOjnO
 
+openai:
+  api-key: ${OPENAI_API_KEY}
+  model: gpt-4o-mini
+
+spring:
   jpa:
     hibernate:
       database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/StarList-Backend/app/src/main/resources/application-prod.yml
+++ b/StarList-Backend/app/src/main/resources/application-prod.yml
@@ -1,6 +1,7 @@
 openai:
   api-key: ${OPENAI_API_KEY}
-  model: gpt-4o-mini
+  model: gpt-4.1-mini
+
 
 spring:
   datasource:

--- a/StarList-Backend/app/src/main/resources/application-prod.yml
+++ b/StarList-Backend/app/src/main/resources/application-prod.yml
@@ -1,3 +1,7 @@
+openai:
+  api-key: ${OPENAI_API_KEY}
+  model: gpt-4o-mini
+
 spring:
   datasource:
     url: ${AWS_DB_URL}

--- a/StarList-Backend/controller/src/main/java/controller/AiController.java
+++ b/StarList-Backend/controller/src/main/java/controller/AiController.java
@@ -1,0 +1,54 @@
+package controller;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import service.AiService;
+import service.UserService;
+import service.dto.AiChatRequest;
+import service.dto.AiChatResponse;
+import service.dto.AiConversationHistoryResponse;
+
+@RestController
+@RequestMapping("/ai")
+public class AiController {
+
+    private final AiService aiService;
+    private final UserService userService;
+
+    public AiController(AiService aiService, UserService userService) {
+        this.aiService = aiService;
+        this.userService = userService;
+    }
+
+    /** Sends a message to the AI assistant and returns its response. */
+    @PostMapping("/chat")
+    public ResponseEntity<AiChatResponse> chat(
+            @AuthenticationPrincipal Jwt jwt,
+            @Valid @RequestBody AiChatRequest request) {
+        Long userId = userService.getUserByCognitoSub(jwt.getSubject()).id();
+        return ResponseEntity.ok(aiService.chat(userId, request));
+    }
+
+    /** Returns a concise daily briefing: due-soon tasks, habits needing attention, and a motivational note. */
+    @GetMapping("/briefing")
+    public ResponseEntity<AiChatResponse> getDailyBriefing(@AuthenticationPrincipal Jwt jwt) {
+        Long userId = userService.getUserByCognitoSub(jwt.getSubject()).id();
+        return ResponseEntity.ok(aiService.getDailyBriefing(userId));
+    }
+
+    /** Returns the full conversation history for the authenticated user, newest-first. */
+    @GetMapping("/history")
+    public ResponseEntity<List<AiConversationHistoryResponse>> getHistory(
+            @AuthenticationPrincipal Jwt jwt) {
+        Long userId = userService.getUserByCognitoSub(jwt.getSubject()).id();
+        return ResponseEntity.ok(aiService.getHistory(userId));
+    }
+}

--- a/StarList-Backend/controller/src/main/java/controller/GlobalExceptionHandler.java
+++ b/StarList-Backend/controller/src/main/java/controller/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import com.openai.errors.RateLimitException;
 import service.exceptions.ConflictException;
 import service.exceptions.NotFoundException;
 
@@ -87,6 +88,16 @@ public class GlobalExceptionHandler {
         problem.setDetail("The request body could not be parsed. Check that the JSON is valid and all required fields are present.");
         problem.setInstance(URI.create(request.getRequestURI()));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
+    }
+
+    @ExceptionHandler(RateLimitException.class)
+    public ResponseEntity<ProblemDetail> handleOpenAiRateLimit(RateLimitException e, HttpServletRequest request) {
+        log.warn("OpenAI quota exceeded [uri={}]", request.getRequestURI());
+        ProblemDetail problem = ProblemDetail.forStatus(HttpStatus.SERVICE_UNAVAILABLE);
+        problem.setTitle("AI service unavailable");
+        problem.setDetail("The AI service is temporarily unavailable due to quota limits. Please try again later.");
+        problem.setInstance(URI.create(request.getRequestURI()));
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(problem);
     }
 
     @ExceptionHandler(Exception.class)

--- a/StarList-Backend/controller/src/main/java/controller/StoreController.java
+++ b/StarList-Backend/controller/src/main/java/controller/StoreController.java
@@ -7,11 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import service.StoreService;
 import service.UserService;
 import service.dto.BuyItemResponse;
@@ -54,7 +50,10 @@ public class StoreController {
      * Returns all items owned by the authenticated user.
      */
     @GetMapping("/my-items")
-    public ResponseEntity<List<GalaxyItem>> getMyItems(@RequestHeader("X-User-Id") Long userId) {
+    public ResponseEntity<List<GalaxyItem>> getMyItems(
+            @AuthenticationPrincipal Jwt jwt
+    ) {
+        Long userId = userService.getUserByCognitoSub(jwt.getSubject()).id();
         return ResponseEntity.ok(storeService.getMyItems(userId));
     }
 }

--- a/StarList-Backend/repository/src/main/java/repository/api/AiConversationRepository.java
+++ b/StarList-Backend/repository/src/main/java/repository/api/AiConversationRepository.java
@@ -1,6 +1,15 @@
 package repository.api;
 
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import repository.entity.AiConversationEntity;
 
-public interface AiConversationRepository extends JpaRepository<AiConversationEntity, Long> {}
+public interface AiConversationRepository extends JpaRepository<AiConversationEntity, Long> {
+
+    /** Returns the most recent {@code pageable.getPageSize()} turns for a user, newest-first. */
+    List<AiConversationEntity> findAllByUser_IdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    /** Returns all conversation turns for a user, newest-first. */
+    List<AiConversationEntity> findAllByUser_IdOrderByCreatedAtDesc(Long userId);
+}

--- a/StarList-Backend/service/pom.xml
+++ b/StarList-Backend/service/pom.xml
@@ -37,6 +37,11 @@
             <version>26.1.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.openai</groupId>
+            <artifactId>openai-java</artifactId>
+            <version>2.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/StarList-Backend/service/src/main/java/service/AiService.java
+++ b/StarList-Backend/service/src/main/java/service/AiService.java
@@ -58,9 +58,11 @@ public class AiService {
     private final HabitService habitService;
     private final UserService userService;
     private final AiConversationRepository aiConversationRepository;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .findAndRegisterModules()
+            .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-    @Value("${openai.model:gpt-4o-mini}")
+    @Value("${openai.model:gpt-5-nano}")
     private String model;
 
     public AiService(OpenAIClient openAIClient, TaskService taskService, HabitService habitService,
@@ -152,7 +154,7 @@ public class AiService {
                                 "difficultyLevel", Map.of("type", "string",
                                         "description", "NONE, EASY, MEDIUM, HARD, VERY_HARD, or EXTREME"),
                                 "durationMinutes", Map.of("type", "integer", "description", "Duration in minutes, positive"),
-                                "dueDate", Map.of("type", "string", "description", "ISO-8601 UTC due date, must be future")
+                                "dueDate", Map.of("type", "string", "description", "Local ISO-8601 datetime with the user's UTC offset (e.g. 2026-05-09T21:35:00+03:00). Must be in the future in the user's local time.")
                         ), List.of("title", "difficultyLevel"))),
                 tool("update_task", "Update an existing task's fields",
                         params(Map.of(
@@ -203,7 +205,7 @@ public class AiService {
         ChatCompletionCreateParams.Builder paramsBuilder = ChatCompletionCreateParams.builder()
                 .model(ChatModel.of(model))
                 .maxCompletionTokens(1024)
-                .addSystemMessage(buildSystemPrompt(userEntity, tasks, habits))
+                .addSystemMessage(buildSystemPrompt(userEntity, tasks, habits, request.userTimezone()))
                 .tools(buildTools());
 
         if (!Boolean.TRUE.equals(request.newConversation())) {
@@ -212,8 +214,9 @@ public class AiService {
         paramsBuilder.addUserMessage(request.message());
 
         List<Long> createdTaskIds = new ArrayList<>();
+        List<Long> createdHabitIds = new ArrayList<>();
         Set<String> toolsUsed = new HashSet<>();
-        String aiMessage = runAgenticLoop(paramsBuilder, userId, userEntity, createdTaskIds, toolsUsed);
+        String aiMessage = runAgenticLoop(paramsBuilder, userId, userEntity, createdTaskIds, createdHabitIds, toolsUsed);
 
         ConversationType conversationType = classifyConversation(toolsUsed);
 
@@ -228,12 +231,13 @@ public class AiService {
 
         createdTaskIds.forEach(taskId -> taskService.linkToAiConversation(taskId, saved));
 
-        log.info("AI chat done for user {}: type={}, tasksCreated={}", userId, conversationType, createdTaskIds.size());
+        log.info("AI chat done for user {}: type={}, tasksCreated={}, habitsCreated={}", userId, conversationType, createdTaskIds.size(), createdHabitIds.size());
         return AiChatResponse.builder()
                 .conversationId(saved.getId())
                 .aiMessage(aiMessage)
                 .conversationType(conversationType)
                 .tasksCreated(createdTaskIds.size())
+                .habitsCreated(createdHabitIds.size())
                 .createdAt(saved.getCreatedAt())
                 .build();
     }
@@ -264,11 +268,22 @@ public class AiService {
 
     private String buildSystemPrompt(UserEntity user,
                                      List<service.dto.TaskResponse> taskList,
-                                     List<service.dto.HabitResponse> habitList) {
-        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+                                     List<service.dto.HabitResponse> habitList,
+                                     String userTimezone) {
+        java.time.ZoneId zone = resolveZone(userTimezone);
+        java.time.ZonedDateTime nowLocal = java.time.ZonedDateTime.now(zone);
+        java.time.ZonedDateTime nowUtc = nowLocal.withZoneSameInstant(ZoneOffset.UTC);
+        LocalDate today = nowLocal.toLocalDate();
 
         StringBuilder sb = new StringBuilder();
         sb.append("You are a personal productivity assistant for StarList, a gamified task and habit tracker.\n");
+        String offsetStr = nowLocal.getOffset().getId(); // e.g. "+03:00"
+        sb.append("User's local time: ").append(nowLocal.toLocalTime().withSecond(0).withNano(0))
+                .append(" (").append(zone).append(", UTC").append(offsetStr).append("). ")
+                .append("UTC now: ").append(nowUtc.toLocalTime().withSecond(0).withNano(0)).append(" UTC.\n");
+        sb.append("When the user mentions a time, interpret it in their local timezone. ")
+                .append("For dueDate, send a local ISO-8601 string with the user's offset (e.g. 2026-05-09T21:35:00").append(offsetStr).append("). ")
+                .append("Validate that the time is in the future relative to the user's current local time above.\n\n");
         sb.append("Today is ").append(today).append(". User: ").append(user.getDisplayName())
                 .append(". Coins: ").append(user.getTotalCoins())
                 .append(", Lifetime earned: ").append(user.getLifetimeCoinsEarned()).append(".\n\n");
@@ -300,8 +315,10 @@ public class AiService {
         }
 
         sb.append("\n=== INSTRUCTIONS ===\n");
-        sb.append("Help manage tasks and habits. Suggest appropriate difficulty and duration when creating tasks. "
-                + "Be concise and encouraging. Confirm destructive actions (delete) before executing unless user explicitly says to just do it.");
+        sb.append("Help manage tasks and habits. Suggest appropriate difficulty and duration when creating tasks. Be concise and encouraging.\n");
+        sb.append("IMPORTANT: Before calling any create, update, or delete tool, always describe what you are about to do in plain, friendly language and ask the user to confirm. ")
+                .append("Never show ISO dates, UTC offsets, or timezone codes to the user — use natural phrasing like 'tonight at 10pm' or 'tomorrow morning'. ")
+                .append("Example: \"Got it! Shall I add a task 'Go to bed' due tonight at 22:00?\" — only call the tool after the user explicitly approves.");
 
         return sb.toString();
     }
@@ -330,18 +347,21 @@ public class AiService {
         List<AiConversationEntity> history = aiConversationRepository
                 .findAllByUser_IdOrderByCreatedAtDesc(userId, PageRequest.of(0, HISTORY_TURNS));
         Collections.reverse(history);
-        history.forEach(turn -> {
-            paramsBuilder.addMessage(ChatCompletionUserMessageParam.builder()
-                    .content(turn.getUserMessage()).build());
-            paramsBuilder.addMessage(ChatCompletionAssistantMessageParam.builder()
-                    .content(turn.getAiResponse()).build());
-        });
+        history.stream()
+                .filter(turn -> !turn.getAiResponse().isBlank())
+                .forEach(turn -> {
+                    paramsBuilder.addMessage(ChatCompletionUserMessageParam.builder()
+                            .content(turn.getUserMessage()).build());
+                    paramsBuilder.addMessage(ChatCompletionAssistantMessageParam.builder()
+                            .content(turn.getAiResponse()).build());
+                });
     }
 
     private String runAgenticLoop(ChatCompletionCreateParams.Builder paramsBuilder,
                                   Long userId,
                                   UserEntity userEntity,
                                   List<Long> createdTaskIds,
+                                  List<Long> createdHabitIds,
                                   Set<String> toolsUsed) {
         String finalResponse = "I'm sorry, I couldn't process your request. Please try again.";
 
@@ -356,7 +376,13 @@ public class AiService {
                     .stream().flatMap(Collection::stream).toList();
 
             if (toolCalls.isEmpty()) {
-                finalResponse = assistantMessage.content().orElse(finalResponse);
+                log.info("AI final response: finishReason={}, contentPresent={}, content='{}'",
+                        completion.choices().get(0).finishReason(),
+                        assistantMessage.content().isPresent(),
+                        assistantMessage.content().orElse("<empty>"));
+                finalResponse = assistantMessage.content()
+                        .filter(s -> !s.isBlank())
+                        .orElse(finalResponse);
                 break;
             }
 
@@ -370,7 +396,7 @@ public class AiService {
                 log.debug("Executing AI tool: {}", toolName);
 
                 Object result = dispatchTool(toolName, toolCall.function(), userId,
-                        userEntity, createdTaskIds);
+                        userEntity, createdTaskIds, createdHabitIds);
 
                 String resultJson;
                 try {
@@ -394,7 +420,8 @@ public class AiService {
                                 ChatCompletionMessageToolCall.Function fn,
                                 Long userId,
                                 UserEntity userEntity,
-                                List<Long> createdTaskIds) {
+                                List<Long> createdTaskIds,
+                                List<Long> createdHabitIds) {
         try {
             return switch (name) {
                 case "get_tasks" -> taskService.getUserTasks(userId);
@@ -410,7 +437,7 @@ public class AiService {
                             .description(args.description)
                             .difficultyLevel(parseDifficulty(args.difficultyLevel))
                             .durationMinutes(args.durationMinutes)
-                            .dueDate(args.dueDate != null ? Instant.parse(args.dueDate) : null)
+                            .dueDate(args.dueDate != null ? java.time.OffsetDateTime.parse(args.dueDate).toInstant() : null)
                             .build();
                     var created = taskService.addTask(userId, req);
                     createdTaskIds.add(created.taskId());
@@ -432,12 +459,14 @@ public class AiService {
                 }
                 case "create_habit" -> {
                     var args = objectMapper.readValue(fn.arguments(), CreateHabitArgs.class);
-                    yield habitService.addHabit(userId, AddHabitRequest.builder()
+                    var created = habitService.addHabit(userId, AddHabitRequest.builder()
                             .title(args.title)
                             .description(args.description)
                             .frequency(HabitFrequency.valueOf(args.frequency.toUpperCase()))
                             .difficultyLevel(parseDifficulty(args.difficultyLevel))
                             .build());
+                    createdHabitIds.add(created.habitId());
+                    yield created;
                 }
                 case "update_habit" -> {
                     var args = objectMapper.readValue(fn.arguments(), UpdateHabitArgs.class);
@@ -475,6 +504,16 @@ public class AiService {
             return ConversationType.STUDY_PLAN;
         }
         return ConversationType.GENERAL_CHAT;
+    }
+
+    private java.time.ZoneId resolveZone(String userTimezone) {
+        if (userTimezone == null || userTimezone.isBlank()) return ZoneOffset.UTC;
+        try {
+            return java.time.ZoneId.of(userTimezone);
+        } catch (Exception e) {
+            log.warn("Invalid timezone '{}', falling back to UTC", userTimezone);
+            return ZoneOffset.UTC;
+        }
     }
 
     private DifficultyLevel parseDifficulty(String value) {

--- a/StarList-Backend/service/src/main/java/service/AiService.java
+++ b/StarList-Backend/service/src/main/java/service/AiService.java
@@ -1,0 +1,489 @@
+package service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openai.client.OpenAIClient;
+import com.openai.core.JsonValue;
+import com.openai.models.ChatModel;
+import com.openai.models.FunctionDefinition;
+import com.openai.models.FunctionParameters;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionAssistantMessageParam;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.openai.models.chat.completions.ChatCompletionMessage;
+import com.openai.models.chat.completions.ChatCompletionMessageToolCall;
+import com.openai.models.chat.completions.ChatCompletionTool;
+import com.openai.models.chat.completions.ChatCompletionToolMessageParam;
+import com.openai.models.chat.completions.ChatCompletionUserMessageParam;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import model.enums.ConversationType;
+import model.enums.DifficultyLevel;
+import model.enums.HabitFrequency;
+import model.enums.TaskStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import repository.api.AiConversationRepository;
+import repository.entity.AiConversationEntity;
+import repository.entity.UserEntity;
+import service.dto.AddHabitRequest;
+import service.dto.AddTaskRequest;
+import service.dto.AiChatRequest;
+import service.dto.AiChatResponse;
+import service.dto.AiConversationHistoryResponse;
+import service.dto.UpdateHabitRequest;
+import service.dto.UpdateTaskRequest;
+
+@Slf4j
+@Service
+public class AiService {
+
+    private static final int HISTORY_TURNS = 10;
+    private static final int MAX_TOOL_ITERATIONS = 5;
+
+    private final OpenAIClient openAIClient;
+    private final TaskService taskService;
+    private final HabitService habitService;
+    private final UserService userService;
+    private final AiConversationRepository aiConversationRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${openai.model:gpt-4o-mini}")
+    private String model;
+
+    public AiService(OpenAIClient openAIClient, TaskService taskService, HabitService habitService,
+                     UserService userService, AiConversationRepository aiConversationRepository) {
+        this.openAIClient = openAIClient;
+        this.taskService = taskService;
+        this.habitService = habitService;
+        this.userService = userService;
+        this.aiConversationRepository = aiConversationRepository;
+    }
+
+    // ─────────────────────────── Tool argument POJOs ───────────────────────────
+
+    static class CreateTaskArgs {
+        public String title;
+        public String description;
+        public String difficultyLevel;
+        public Integer durationMinutes;
+        public String dueDate;
+    }
+
+    static class UpdateTaskArgs {
+        public Long taskId;
+        public String title;
+        public String description;
+        public String difficultyLevel;
+        public Integer durationMinutes;
+    }
+
+    static class DeleteTaskArgs {
+        public Long taskId;
+    }
+
+    static class CreateHabitArgs {
+        public String title;
+        public String description;
+        public String frequency;
+        public String difficultyLevel;
+    }
+
+    static class UpdateHabitArgs {
+        public Long habitId;
+        public String title;
+        public String description;
+        public String frequency;
+        public String difficultyLevel;
+    }
+
+    static class DeleteHabitArgs {
+        public Long habitId;
+    }
+
+    // ─────────────────────────── Tool definitions ───────────────────────────
+
+    private static FunctionParameters noParams() {
+        return FunctionParameters.builder()
+                .putAdditionalProperty("type", JsonValue.from("object"))
+                .putAdditionalProperty("properties", JsonValue.from(Map.of()))
+                .build();
+    }
+
+    private static FunctionParameters params(Map<String, Object> properties, List<String> required) {
+        return FunctionParameters.builder()
+                .putAdditionalProperty("type", JsonValue.from("object"))
+                .putAdditionalProperty("properties", JsonValue.from(properties))
+                .putAdditionalProperty("required", JsonValue.from(required))
+                .build();
+    }
+
+    private static ChatCompletionTool tool(String name, String description, FunctionParameters parameters) {
+        return ChatCompletionTool.builder()
+                .function(FunctionDefinition.builder()
+                        .name(name)
+                        .description(description)
+                        .parameters(parameters)
+                        .build())
+                .build();
+    }
+
+    private static List<ChatCompletionTool> buildTools() {
+        return List.of(
+                tool("get_tasks", "Get all active (non-deleted) tasks for the user", noParams()),
+                tool("get_habits", "Get all active habits for the user with streaks", noParams()),
+                tool("get_user_stats", "Get the user's coin balance and lifetime stats", noParams()),
+                tool("create_task", "Create a new task for the user",
+                        params(Map.of(
+                                "title", Map.of("type", "string", "description", "Task title (required)"),
+                                "description", Map.of("type", "string", "description", "Optional description"),
+                                "difficultyLevel", Map.of("type", "string",
+                                        "description", "NONE, EASY, MEDIUM, HARD, VERY_HARD, or EXTREME"),
+                                "durationMinutes", Map.of("type", "integer", "description", "Duration in minutes, positive"),
+                                "dueDate", Map.of("type", "string", "description", "ISO-8601 UTC due date, must be future")
+                        ), List.of("title", "difficultyLevel"))),
+                tool("update_task", "Update an existing task's fields",
+                        params(Map.of(
+                                "taskId", Map.of("type", "integer", "description", "ID of the task to update"),
+                                "title", Map.of("type", "string"),
+                                "description", Map.of("type", "string"),
+                                "difficultyLevel", Map.of("type", "string"),
+                                "durationMinutes", Map.of("type", "integer")
+                        ), List.of("taskId"))),
+                tool("delete_task", "Soft-delete a task by ID",
+                        params(Map.of("taskId", Map.of("type", "integer", "description", "ID to delete")),
+                                List.of("taskId"))),
+                tool("create_habit", "Create a new habit for the user",
+                        params(Map.of(
+                                "title", Map.of("type", "string", "description", "Habit title"),
+                                "description", Map.of("type", "string"),
+                                "frequency", Map.of("type", "string", "description", "DAILY, WEEKLY, or CUSTOM"),
+                                "difficultyLevel", Map.of("type", "string", "description", "NONE, EASY, MEDIUM, HARD, VERY_HARD, or EXTREME")
+                        ), List.of("title", "frequency", "difficultyLevel"))),
+                tool("update_habit", "Update an existing habit's fields",
+                        params(Map.of(
+                                "habitId", Map.of("type", "integer", "description", "ID of the habit to update"),
+                                "title", Map.of("type", "string"),
+                                "description", Map.of("type", "string"),
+                                "frequency", Map.of("type", "string"),
+                                "difficultyLevel", Map.of("type", "string")
+                        ), List.of("habitId"))),
+                tool("delete_habit", "Soft-delete a habit by ID",
+                        params(Map.of("habitId", Map.of("type", "integer", "description", "ID to delete")),
+                                List.of("habitId")))
+        );
+    }
+
+    // ─────────────────────────── Public API ───────────────────────────
+
+    /**
+     * Handles a user chat message: builds context, runs the agentic tool-call loop,
+     * persists the turn, and returns the AI's final response.
+     */
+    @Transactional
+    public AiChatResponse chat(Long userId, AiChatRequest request) {
+        log.info("AI chat for user {} (newConversation={})", userId, request.newConversation());
+
+        UserEntity userEntity = userService.findEntityById(userId);
+        var tasks = taskService.getUserTasks(userId);
+        var habits = habitService.getUserHabits(userId, YearMonth.now());
+
+        ChatCompletionCreateParams.Builder paramsBuilder = ChatCompletionCreateParams.builder()
+                .model(ChatModel.of(model))
+                .maxCompletionTokens(1024)
+                .addSystemMessage(buildSystemPrompt(userEntity, tasks, habits))
+                .tools(buildTools());
+
+        if (!Boolean.TRUE.equals(request.newConversation())) {
+            appendHistory(paramsBuilder, userId);
+        }
+        paramsBuilder.addUserMessage(request.message());
+
+        List<Long> createdTaskIds = new ArrayList<>();
+        Set<String> toolsUsed = new HashSet<>();
+        String aiMessage = runAgenticLoop(paramsBuilder, userId, userEntity, createdTaskIds, toolsUsed);
+
+        ConversationType conversationType = classifyConversation(toolsUsed);
+
+        AiConversationEntity saved = aiConversationRepository.save(
+                AiConversationEntity.builder()
+                        .user(userEntity)
+                        .userMessage(request.message())
+                        .aiResponse(aiMessage)
+                        .conversationType(conversationType)
+                        .tasksCreated(createdTaskIds.size())
+                        .build());
+
+        createdTaskIds.forEach(taskId -> taskService.linkToAiConversation(taskId, saved));
+
+        log.info("AI chat done for user {}: type={}, tasksCreated={}", userId, conversationType, createdTaskIds.size());
+        return AiChatResponse.builder()
+                .conversationId(saved.getId())
+                .aiMessage(aiMessage)
+                .conversationType(conversationType)
+                .tasksCreated(createdTaskIds.size())
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+
+    /** Returns a short daily briefing of tasks due soon, habits to complete, and a motivational note. */
+    @Transactional
+    public AiChatResponse getDailyBriefing(Long userId) {
+        log.info("Daily briefing for user {}", userId);
+        return chat(userId, AiChatRequest.builder()
+                .message("Give me a concise daily briefing: list tasks due today or tomorrow, "
+                        + "habits I still need to complete today, and one short motivational note. "
+                        + "Keep it under 150 words.")
+                .newConversation(false)
+                .build());
+    }
+
+    /** Returns the full conversation history for a user, newest-first. */
+    @Transactional(readOnly = true)
+    public List<AiConversationHistoryResponse> getHistory(Long userId) {
+        log.info("Fetching AI history for user {}", userId);
+        return aiConversationRepository.findAllByUser_IdOrderByCreatedAtDesc(userId)
+                .stream()
+                .map(AiConversationHistoryResponse::from)
+                .toList();
+    }
+
+    // ─────────────────────────── Private helpers ───────────────────────────
+
+    private String buildSystemPrompt(UserEntity user,
+                                     List<service.dto.TaskResponse> taskList,
+                                     List<service.dto.HabitResponse> habitList) {
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("You are a personal productivity assistant for StarList, a gamified task and habit tracker.\n");
+        sb.append("Today is ").append(today).append(". User: ").append(user.getDisplayName())
+                .append(". Coins: ").append(user.getTotalCoins())
+                .append(", Lifetime earned: ").append(user.getLifetimeCoinsEarned()).append(".\n\n");
+
+        sb.append("=== TASKS ===\n");
+        if (taskList.isEmpty()) {
+            sb.append("No active tasks.\n");
+        } else {
+            taskList.forEach(t -> sb.append(String.format(
+                    "- [id:%d] \"%s\" | %s | %s | due:%s\n",
+                    t.taskId(), t.title(), t.status(), t.difficultyLevel(),
+                    t.dueDate() != null ? t.dueDate() : "none")));
+        }
+
+        sb.append("\n=== HABITS ===\n");
+        if (habitList.isEmpty()) {
+            sb.append("No active habits.\n");
+        } else {
+            habitList.forEach(h -> sb.append(String.format(
+                    "- [id:%d] \"%s\" | %s | streak:%d | best:%d | lastDone:%s\n",
+                    h.habitId(), h.title(), h.frequency(), h.currentStreak(), h.bestStreak(),
+                    h.lastCompletedDate() != null ? h.lastCompletedDate() : "never")));
+        }
+
+        List<String> notices = buildCoachNotices(taskList, habitList, today);
+        if (!notices.isEmpty()) {
+            sb.append("\n=== COACH NOTICES ===\n");
+            notices.forEach(n -> sb.append("⚠ ").append(n).append("\n"));
+        }
+
+        sb.append("\n=== INSTRUCTIONS ===\n");
+        sb.append("Help manage tasks and habits. Suggest appropriate difficulty and duration when creating tasks. "
+                + "Be concise and encouraging. Confirm destructive actions (delete) before executing unless user explicitly says to just do it.");
+
+        return sb.toString();
+    }
+
+    private List<String> buildCoachNotices(List<service.dto.TaskResponse> tasks,
+                                           List<service.dto.HabitResponse> habits, LocalDate today) {
+        List<String> notices = new ArrayList<>();
+
+        tasks.stream()
+                .filter(t -> t.status() == TaskStatus.PENDING
+                        && t.dueDate() != null
+                        && t.dueDate().isBefore(Instant.now()))
+                .forEach(t -> notices.add("Task \"" + t.title() + "\" is overdue!"));
+
+        habits.stream()
+                .filter(h -> h.frequency() == HabitFrequency.DAILY
+                        && Boolean.TRUE.equals(h.isActive())
+                        && (h.lastCompletedDate() == null || h.lastCompletedDate().isBefore(today)))
+                .forEach(h -> notices.add("Daily habit \"" + h.title()
+                        + "\" hasn't been done today (streak: " + h.currentStreak() + ")"));
+
+        return notices;
+    }
+
+    private void appendHistory(ChatCompletionCreateParams.Builder paramsBuilder, Long userId) {
+        List<AiConversationEntity> history = aiConversationRepository
+                .findAllByUser_IdOrderByCreatedAtDesc(userId, PageRequest.of(0, HISTORY_TURNS));
+        Collections.reverse(history);
+        history.forEach(turn -> {
+            paramsBuilder.addMessage(ChatCompletionUserMessageParam.builder()
+                    .content(turn.getUserMessage()).build());
+            paramsBuilder.addMessage(ChatCompletionAssistantMessageParam.builder()
+                    .content(turn.getAiResponse()).build());
+        });
+    }
+
+    private String runAgenticLoop(ChatCompletionCreateParams.Builder paramsBuilder,
+                                  Long userId,
+                                  UserEntity userEntity,
+                                  List<Long> createdTaskIds,
+                                  Set<String> toolsUsed) {
+        String finalResponse = "I'm sorry, I couldn't process your request. Please try again.";
+
+        for (int iteration = 0; iteration < MAX_TOOL_ITERATIONS; iteration++) {
+            ChatCompletion completion = openAIClient.chat().completions()
+                    .create(paramsBuilder.build());
+
+            ChatCompletionMessage assistantMessage = completion.choices().get(0).message();
+            paramsBuilder.addMessage(assistantMessage);
+
+            List<ChatCompletionMessageToolCall> toolCalls = assistantMessage.toolCalls()
+                    .stream().flatMap(Collection::stream).toList();
+
+            if (toolCalls.isEmpty()) {
+                finalResponse = assistantMessage.content().orElse(finalResponse);
+                break;
+            }
+
+            if (iteration == MAX_TOOL_ITERATIONS - 1) {
+                log.warn("AI tool-call loop hit max iterations ({}) for user {}", MAX_TOOL_ITERATIONS, userId);
+            }
+
+            for (ChatCompletionMessageToolCall toolCall : toolCalls) {
+                String toolName = toolCall.function().name();
+                toolsUsed.add(toolName);
+                log.debug("Executing AI tool: {}", toolName);
+
+                Object result = dispatchTool(toolName, toolCall.function(), userId,
+                        userEntity, createdTaskIds);
+
+                String resultJson;
+                try {
+                    resultJson = objectMapper.writeValueAsString(result);
+                } catch (JsonProcessingException e) {
+                    log.error("Failed to serialize tool result for {}", toolName, e);
+                    resultJson = "{\"error\":\"serialization failed\"}";
+                }
+
+                paramsBuilder.addMessage(ChatCompletionToolMessageParam.builder()
+                        .toolCallId(toolCall.id())
+                        .content(resultJson)
+                        .build());
+            }
+        }
+
+        return finalResponse;
+    }
+
+    private Object dispatchTool(String name,
+                                ChatCompletionMessageToolCall.Function fn,
+                                Long userId,
+                                UserEntity userEntity,
+                                List<Long> createdTaskIds) {
+        try {
+            return switch (name) {
+                case "get_tasks" -> taskService.getUserTasks(userId);
+                case "get_habits" -> habitService.getUserHabits(userId, YearMonth.now());
+                case "get_user_stats" -> Map.of(
+                        "displayName", userEntity.getDisplayName(),
+                        "totalCoins", userEntity.getTotalCoins(),
+                        "lifetimeCoinsEarned", userEntity.getLifetimeCoinsEarned());
+                case "create_task" -> {
+                    var args = objectMapper.readValue(fn.arguments(), CreateTaskArgs.class);
+                    var req = AddTaskRequest.builder()
+                            .title(args.title)
+                            .description(args.description)
+                            .difficultyLevel(parseDifficulty(args.difficultyLevel))
+                            .durationMinutes(args.durationMinutes)
+                            .dueDate(args.dueDate != null ? Instant.parse(args.dueDate) : null)
+                            .build();
+                    var created = taskService.addTask(userId, req);
+                    createdTaskIds.add(created.taskId());
+                    yield created;
+                }
+                case "update_task" -> {
+                    var args = objectMapper.readValue(fn.arguments(), UpdateTaskArgs.class);
+                    yield taskService.updateTask(args.taskId, UpdateTaskRequest.builder()
+                            .title(args.title)
+                            .description(args.description)
+                            .difficultyLevel(args.difficultyLevel != null ? parseDifficulty(args.difficultyLevel) : null)
+                            .durationMinutes(args.durationMinutes)
+                            .build());
+                }
+                case "delete_task" -> {
+                    var args = objectMapper.readValue(fn.arguments(), DeleteTaskArgs.class);
+                    taskService.deleteTask(args.taskId);
+                    yield Map.of("deleted", true, "taskId", args.taskId);
+                }
+                case "create_habit" -> {
+                    var args = objectMapper.readValue(fn.arguments(), CreateHabitArgs.class);
+                    yield habitService.addHabit(userId, AddHabitRequest.builder()
+                            .title(args.title)
+                            .description(args.description)
+                            .frequency(HabitFrequency.valueOf(args.frequency.toUpperCase()))
+                            .difficultyLevel(parseDifficulty(args.difficultyLevel))
+                            .build());
+                }
+                case "update_habit" -> {
+                    var args = objectMapper.readValue(fn.arguments(), UpdateHabitArgs.class);
+                    yield habitService.updateHabit(args.habitId, UpdateHabitRequest.builder()
+                            .title(args.title)
+                            .description(args.description)
+                            .frequency(args.frequency != null ? HabitFrequency.valueOf(args.frequency.toUpperCase()) : null)
+                            .difficultyLevel(args.difficultyLevel != null ? parseDifficulty(args.difficultyLevel) : null)
+                            .build());
+                }
+                case "delete_habit" -> {
+                    var args = objectMapper.readValue(fn.arguments(), DeleteHabitArgs.class);
+                    habitService.deleteHabit(args.habitId);
+                    yield Map.of("deleted", true, "habitId", args.habitId);
+                }
+                default -> {
+                    log.warn("Unknown AI tool: {}", name);
+                    yield Map.of("error", "Unknown tool: " + name);
+                }
+            };
+        } catch (Exception e) {
+            log.error("Tool '{}' execution failed", name, e);
+            return Map.of("error", e.getMessage());
+        }
+    }
+
+    private ConversationType classifyConversation(Set<String> toolsUsed) {
+        if (toolsUsed.contains("create_task") || toolsUsed.contains("update_task") || toolsUsed.contains("delete_task")) {
+            return ConversationType.TASK_CREATION;
+        }
+        if (toolsUsed.contains("create_habit") || toolsUsed.contains("update_habit") || toolsUsed.contains("delete_habit")) {
+            return ConversationType.HABIT_SUGGESTION;
+        }
+        if (toolsUsed.contains("get_user_stats")) {
+            return ConversationType.STUDY_PLAN;
+        }
+        return ConversationType.GENERAL_CHAT;
+    }
+
+    private DifficultyLevel parseDifficulty(String value) {
+        if (value == null) return DifficultyLevel.NONE;
+        try {
+            return DifficultyLevel.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("Unknown difficulty '{}', defaulting to MEDIUM", value);
+            return DifficultyLevel.MEDIUM;
+        }
+    }
+}

--- a/StarList-Backend/service/src/main/java/service/TaskService.java
+++ b/StarList-Backend/service/src/main/java/service/TaskService.java
@@ -182,6 +182,20 @@ public class TaskService {
         taskRepository.save(entity);
     }
 
+    /**
+     * Links an existing task to the AI conversation that created it and marks it as AI-created.
+     * Called by {@link AiService} after persisting the conversation turn.
+     */
+    @Transactional
+    public void linkToAiConversation(Long taskId, repository.entity.AiConversationEntity aiConversation) {
+        log.info("Linking task {} to AI conversation {}", taskId, aiConversation.getId());
+        TaskEntity entity = taskRepository.findById(taskId)
+                .orElseThrow(() -> new TaskNotFoundException(taskId));
+        entity.setCreatedByAi(true);
+        entity.setAiConversation(aiConversation);
+        taskRepository.save(entity);
+    }
+
     /** Loads an active (non-deleted) task by ID, throwing {@link TaskNotFoundException} if absent or soft-deleted. */
     private TaskEntity loadActiveTask(Long taskId) {
         return taskRepository.findById(taskId)

--- a/StarList-Backend/service/src/main/java/service/dto/AddTaskRequest.java
+++ b/StarList-Backend/service/src/main/java/service/dto/AddTaskRequest.java
@@ -14,5 +14,5 @@ public record AddTaskRequest(
         String description,
         @NotNull DifficultyLevel difficultyLevel,
         @Positive Integer durationMinutes,
-        @Future Instant dueDate
+        Instant dueDate
 ) {}

--- a/StarList-Backend/service/src/main/java/service/dto/AiChatRequest.java
+++ b/StarList-Backend/service/src/main/java/service/dto/AiChatRequest.java
@@ -1,0 +1,10 @@
+package service.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+@Builder
+public record AiChatRequest(
+        @NotBlank String message,
+        Boolean newConversation
+) {}

--- a/StarList-Backend/service/src/main/java/service/dto/AiChatRequest.java
+++ b/StarList-Backend/service/src/main/java/service/dto/AiChatRequest.java
@@ -6,5 +6,7 @@ import lombok.Builder;
 @Builder
 public record AiChatRequest(
         @NotBlank String message,
-        Boolean newConversation
+        Boolean newConversation,
+        /** IANA timezone string from the client (e.g. "Asia/Jerusalem"). Null falls back to UTC. */
+        String userTimezone
 ) {}

--- a/StarList-Backend/service/src/main/java/service/dto/AiChatResponse.java
+++ b/StarList-Backend/service/src/main/java/service/dto/AiChatResponse.java
@@ -10,5 +10,6 @@ public record AiChatResponse(
         String aiMessage,
         ConversationType conversationType,
         Integer tasksCreated,
+        Integer habitsCreated,
         Instant createdAt
 ) {}

--- a/StarList-Backend/service/src/main/java/service/dto/AiChatResponse.java
+++ b/StarList-Backend/service/src/main/java/service/dto/AiChatResponse.java
@@ -1,0 +1,14 @@
+package service.dto;
+
+import java.time.Instant;
+import lombok.Builder;
+import model.enums.ConversationType;
+
+@Builder
+public record AiChatResponse(
+        Long conversationId,
+        String aiMessage,
+        ConversationType conversationType,
+        Integer tasksCreated,
+        Instant createdAt
+) {}

--- a/StarList-Backend/service/src/main/java/service/dto/AiConversationHistoryResponse.java
+++ b/StarList-Backend/service/src/main/java/service/dto/AiConversationHistoryResponse.java
@@ -1,0 +1,28 @@
+package service.dto;
+
+import java.time.Instant;
+import lombok.Builder;
+import model.enums.ConversationType;
+import repository.entity.AiConversationEntity;
+
+@Builder
+public record AiConversationHistoryResponse(
+        Long conversationId,
+        String userMessage,
+        String aiResponse,
+        ConversationType conversationType,
+        Integer tasksCreated,
+        Instant createdAt
+) {
+
+    public static AiConversationHistoryResponse from(AiConversationEntity entity) {
+        return AiConversationHistoryResponse.builder()
+                .conversationId(entity.getId())
+                .userMessage(entity.getUserMessage())
+                .aiResponse(entity.getAiResponse())
+                .conversationType(entity.getConversationType())
+                .tasksCreated(entity.getTasksCreated())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -17,6 +17,7 @@ import { UserProvider, useUser } from "../context/UserContext";
 import { tasksApi, TaskResponse, AddTaskRequest } from "../services/taskApi";
 import { habitsApi, HabitResponse, AddHabitRequest, UpdateHabitRequest } from "../services/habitsApi";
 import { storeApi, ItemCatalogResponse } from "../services/storeApi";
+import { aiApi } from "../services/aiApi";
 
 type Screen = 'tasks' | 'habits' | 'galaxy' | 'chat' | 'profile' | 'shop' | 'statistics';
 
@@ -245,16 +246,81 @@ function MainApp() {
     }
   };
 
-  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([
-    { id: '1', type: 'ai', content: 'Hello! How can I help today?', timestamp: new Date() },
-  ]);
+  const [chatMessages, setChatMessages] = useState<ChatMessage[]>([]);
+  const [isAiLoading, setIsAiLoading] = useState(false);
+  const [chatHistoryLoaded, setChatHistoryLoaded] = useState(false);
 
   const [isAddTaskModalOpen, setIsAddTaskModalOpen] = useState(false);
   const [isAddHabitModalOpen, setIsAddHabitModalOpen] = useState(false);
 
-  const handleSendMessage = (message: string) => {
-    const newMessage: ChatMessage = { id: Date.now().toString(), type: 'user', content: message, timestamp: new Date() };
-    setChatMessages([...chatMessages, newMessage]);
+  // Load chat history the first time the user opens the chat screen
+  useEffect(() => {
+    if (currentScreen === 'chat' && !chatHistoryLoaded && user) {
+      aiApi.getHistory().then((history) => {
+        const historyMessages: ChatMessage[] = history
+          .slice()
+          .reverse()
+          .flatMap((turn) => [
+            { id: `u-${turn.conversationId}`, type: 'user' as const, content: turn.userMessage, timestamp: new Date(turn.createdAt) },
+            { id: `a-${turn.conversationId}`, type: 'ai' as const, content: turn.aiResponse, timestamp: new Date(turn.createdAt) },
+          ]);
+        if (historyMessages.length > 0) {
+          setChatMessages(historyMessages);
+        }
+        setChatHistoryLoaded(true);
+      }).catch(() => setChatHistoryLoaded(true));
+    }
+  }, [currentScreen, chatHistoryLoaded, user]);
+
+  const appendAiMessage = (content: string) => {
+    setChatMessages(prev => [...prev, {
+      id: Date.now().toString(),
+      type: 'ai',
+      content,
+      timestamp: new Date(),
+    }]);
+  };
+
+  const handleSendMessage = async (message: string, newConversation?: boolean) => {
+    if (newConversation) {
+      setChatMessages([]);
+      return;
+    }
+    if (!message.trim()) return;
+
+    setChatMessages(prev => [...prev, {
+      id: Date.now().toString(),
+      type: 'user',
+      content: message,
+      timestamp: new Date(),
+    }]);
+    setIsAiLoading(true);
+
+    try {
+      const response = await aiApi.sendMessage({ message, newConversation: false });
+      appendAiMessage(response.aiMessage);
+      if (response.tasksCreated > 0) {
+        const updatedTasks = await tasksApi.getTasks();
+        setTasks(updatedTasks);
+        showToast(`AI created ${response.tasksCreated} task${response.tasksCreated > 1 ? 's' : ''} for you!`);
+      }
+    } catch {
+      appendAiMessage("Sorry, I'm having trouble connecting right now. Please try again.");
+    } finally {
+      setIsAiLoading(false);
+    }
+  };
+
+  const handleDailyBriefing = async () => {
+    setIsAiLoading(true);
+    try {
+      const response = await aiApi.getDailyBriefing();
+      appendAiMessage(response.aiMessage);
+    } catch {
+      appendAiMessage("Couldn't load your daily briefing. Please try again.");
+    } finally {
+      setIsAiLoading(false);
+    }
   };
 
   const handlePurchase = async (itemId: string) => {
@@ -319,7 +385,7 @@ function MainApp() {
           {currentScreen === 'galaxy' && <GalaxyView coinBalance={coinBalance} planets={planets} />}
           {currentScreen === 'tasks' && <TaskDashboard tasks={tasks} onTaskToggle={handleTaskToggle} onQuickAdd={() => setIsAddTaskModalOpen(true)} onOpenChat={() => setCurrentScreen('chat')} onTaskDelete={handleTaskDelete} />}
           {currentScreen === 'habits' && <HabitTracker habits={habits} onHabitCheck={handleHabitCheck} onAddHabitClick={() => setIsAddHabitModalOpen(true)} onEditHabitClick={(h) => { setHabitToEdit(h); setIsEditHabitModalOpen(true); }} onDeleteHabit={handleDeleteHabit} />}
-          {currentScreen === 'chat' && <AIChat messages={chatMessages} onSendMessage={handleSendMessage} onAddTask={() => {}} />}
+          {currentScreen === 'chat' && <AIChat messages={chatMessages} onSendMessage={handleSendMessage} onAddTask={() => {}} onDailyBriefing={handleDailyBriefing} isLoading={isAiLoading} />}
           {currentScreen === 'shop' && <Shop items={shopItems as any} coinBalance={coinBalance} onPurchase={handlePurchase} />}
           {currentScreen === 'statistics' && <Statistics tasks={tasks as any} habits={habits} totalCoinsEarned={coinBalance} currentStreak={0} />}
           {currentScreen === 'profile' && <Profile user={{ name: user?.displayName || 'Explorer', email: user?.email || '', level: 1, xp: 0, xpToNextLevel: 1000, tasksCompleted: 0, achievements: [] }} coinBalance={coinBalance} />}

--- a/frontend/src/app/App.tsx
+++ b/frontend/src/app/App.tsx
@@ -297,12 +297,21 @@ function MainApp() {
     setIsAiLoading(true);
 
     try {
-      const response = await aiApi.sendMessage({ message, newConversation: false });
+      const response = await aiApi.sendMessage({
+        message,
+        newConversation: false,
+        userTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      });
       appendAiMessage(response.aiMessage);
       if (response.tasksCreated > 0) {
         const updatedTasks = await tasksApi.getTasks();
         setTasks(updatedTasks);
         showToast(`AI created ${response.tasksCreated} task${response.tasksCreated > 1 ? 's' : ''} for you!`);
+      }
+      if (response.habitsCreated > 0) {
+        const updatedHabits = await habitsApi.getHabits();
+        setHabits(updatedHabits);
+        showToast(`AI created ${response.habitsCreated} habit${response.habitsCreated > 1 ? 's' : ''} for you!`);
       }
     } catch {
       appendAiMessage("Sorry, I'm having trouble connecting right now. Please try again.");

--- a/frontend/src/app/components/AIChat.tsx
+++ b/frontend/src/app/components/AIChat.tsx
@@ -1,4 +1,4 @@
-import { Send, Bot, User, Plus } from "lucide-react";
+import { Send, Bot, User, Plus, RefreshCw, Sparkles } from "lucide-react";
 import { useState } from "react";
 import { Button } from "./ui/button";
 
@@ -16,18 +16,27 @@ interface Message {
 
 interface AIChatProps {
   messages: Message[];
-  onSendMessage: (message: string) => void;
+  onSendMessage: (message: string, newConversation?: boolean) => void;
   onAddTask: (taskData: any) => void;
+  onDailyBriefing: () => void;
+  isLoading?: boolean;
 }
 
-export function AIChat({ messages, onSendMessage, onAddTask }: AIChatProps) {
+export function AIChat({ messages, onSendMessage, onAddTask, onDailyBriefing, isLoading }: AIChatProps) {
   const [input, setInput] = useState('');
+  const [isNewConversation, setIsNewConversation] = useState(false);
 
   const handleSend = () => {
-    if (input.trim()) {
-      onSendMessage(input);
+    if (input.trim() && !isLoading) {
+      onSendMessage(input, isNewConversation);
       setInput('');
+      setIsNewConversation(false);
     }
+  };
+
+  const handleNewChat = () => {
+    setIsNewConversation(true);
+    onSendMessage('', true);
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
@@ -41,19 +50,49 @@ export function AIChat({ messages, onSendMessage, onAddTask }: AIChatProps) {
     <div className="w-full h-full bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex flex-col">
       {/* Header */}
       <div className="bg-slate-900/95 backdrop-blur-sm border-b border-slate-700/50 px-6 py-4">
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center">
-            <Bot className="w-6 h-6 text-white" />
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center">
+              <Bot className="w-6 h-6 text-white" />
+            </div>
+            <div>
+              <h1 className="text-lg text-white/90">AI Assistant</h1>
+              <p className="text-xs text-green-400">● Online</p>
+            </div>
           </div>
-          <div>
-            <h1 className="text-lg text-white/90">AI Task Assistant</h1>
-            <p className="text-xs text-green-400">● Online</p>
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={onDailyBriefing}
+              disabled={isLoading}
+              variant="outline"
+              size="sm"
+              className="border-purple-500/50 text-purple-300 hover:bg-purple-500/20 disabled:opacity-50"
+            >
+              <Sparkles className="w-4 h-4 mr-1" />
+              Briefing
+            </Button>
+            <Button
+              onClick={handleNewChat}
+              disabled={isLoading}
+              variant="outline"
+              size="sm"
+              className="border-slate-600 text-slate-400 hover:bg-slate-700 disabled:opacity-50"
+            >
+              <RefreshCw className="w-4 h-4 mr-1" />
+              New Chat
+            </Button>
           </div>
         </div>
       </div>
 
       {/* Messages */}
       <div className="flex-1 overflow-y-auto p-6 space-y-4">
+        {messages.length === 0 && (
+          <div className="flex flex-col items-center justify-center h-full text-center gap-4 text-slate-500">
+            <Bot className="w-12 h-12 opacity-30" />
+            <p className="text-sm">Ask me about your tasks, habits, or let me help you add new ones!</p>
+          </div>
+        )}
         {messages.map((message) => (
           <div
             key={message.id}
@@ -61,7 +100,6 @@ export function AIChat({ messages, onSendMessage, onAddTask }: AIChatProps) {
               message.type === 'user' ? 'flex-row-reverse' : 'flex-row'
             }`}
           >
-            {/* Avatar */}
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${
                 message.type === 'user'
@@ -76,14 +114,12 @@ export function AIChat({ messages, onSendMessage, onAddTask }: AIChatProps) {
               )}
             </div>
 
-            {/* Message Content */}
             <div
               className={`max-w-[70%] ${
                 message.type === 'user' ? 'items-end' : 'items-start'
               }`}
             >
               {message.type === 'task-suggestion' && message.taskData ? (
-                // Task suggestion card
                 <div className="bg-slate-800 border border-slate-700 rounded-lg p-4 space-y-3">
                   <p className="text-sm text-slate-300 mb-3">{message.content}</p>
                   <div className="bg-slate-700/50 rounded-lg p-3 border border-slate-600">
@@ -113,7 +149,6 @@ export function AIChat({ messages, onSendMessage, onAddTask }: AIChatProps) {
                   </Button>
                 </div>
               ) : (
-                // Regular message bubble
                 <div
                   className={`rounded-2xl px-4 py-2 ${
                     message.type === 'user'
@@ -121,7 +156,7 @@ export function AIChat({ messages, onSendMessage, onAddTask }: AIChatProps) {
                       : 'bg-slate-800 text-slate-200 border border-slate-700'
                   }`}
                 >
-                  <p className="text-sm">{message.content}</p>
+                  <p className="text-sm whitespace-pre-wrap">{message.content}</p>
                 </div>
               )}
               <span className="text-xs text-slate-500 mt-1 block px-2">
@@ -130,6 +165,22 @@ export function AIChat({ messages, onSendMessage, onAddTask }: AIChatProps) {
             </div>
           </div>
         ))}
+
+        {/* Typing indicator */}
+        {isLoading && (
+          <div className="flex items-start gap-3">
+            <div className="w-8 h-8 rounded-full bg-gradient-to-br from-purple-500 to-blue-500 flex items-center justify-center shrink-0">
+              <Bot className="w-5 h-5 text-white" />
+            </div>
+            <div className="bg-slate-800 border border-slate-700 rounded-2xl px-4 py-3">
+              <div className="flex gap-1 items-center">
+                <span className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+                <span className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+                <span className="w-2 h-2 bg-slate-400 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Input */}
@@ -138,18 +189,16 @@ export function AIChat({ messages, onSendMessage, onAddTask }: AIChatProps) {
           <textarea
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            onKeyPress={handleKeyPress}
-            placeholder="Ask AI to suggest tasks or manage your workflow..."
-            className="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-4 py-3 text-white placeholder-slate-500 resize-none focus:outline-none focus:border-blue-500 transition-colors"
+            onKeyDown={handleKeyPress}
+            disabled={isLoading}
+            placeholder="Ask about your tasks, add a habit, or get productivity tips..."
+            className="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-4 py-3 text-white placeholder-slate-500 resize-none focus:outline-none focus:border-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             rows={1}
-            style={{
-              minHeight: '44px',
-              maxHeight: '120px',
-            }}
+            style={{ minHeight: '44px', maxHeight: '120px' }}
           />
           <Button
             onClick={handleSend}
-            disabled={!input.trim()}
+            disabled={!input.trim() || isLoading}
             className="bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed h-11 px-4"
           >
             <Send className="w-5 h-5" />

--- a/frontend/src/app/components/AddTaskModal.tsx
+++ b/frontend/src/app/components/AddTaskModal.tsx
@@ -13,6 +13,7 @@ export function AddTaskModal({ isOpen, onClose, onAdd }: AddTaskModalProps) {
     const [description, setDescription] = useState("");
     const [difficulty, setDifficulty] = useState<'EASY' | 'MEDIUM' | 'HARD'>('MEDIUM');
     const [durationMinutes, setDurationMinutes] = useState<number>(30);
+    const [dueDate, setDueDate] = useState<string>("");
 
     if (!isOpen) return null;
 
@@ -24,13 +25,15 @@ export function AddTaskModal({ isOpen, onClose, onAdd }: AddTaskModalProps) {
             title,
             description,
             difficultyLevel: difficulty,
-            durationMinutes
+            durationMinutes,
+            dueDate: dueDate ? new Date(dueDate).toISOString() : undefined,
         });
 
         setTitle("");
         setDescription("");
         setDifficulty("MEDIUM");
         setDurationMinutes(30);
+        setDueDate("");
         onClose();
     };
 
@@ -95,6 +98,16 @@ export function AddTaskModal({ isOpen, onClose, onAdd }: AddTaskModalProps) {
                                 className="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500"
                             />
                         </div>
+                    </div>
+
+                    <div>
+                        <label className="block text-sm text-slate-300 mb-1">Due Date (Optional)</label>
+                        <input
+                            type="datetime-local"
+                            value={dueDate}
+                            onChange={(e) => setDueDate(e.target.value)}
+                            className="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:border-blue-500 [color-scheme:dark]"
+                        />
                     </div>
 
                     <div className="pt-4 flex gap-3">

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,9 @@
+import { Amplify } from 'aws-amplify';
 import { createRoot } from "react-dom/client";
 import App from "./app/App";
 import "./styles/index.css";
+import { awsConfig } from "./aws-config";
+
+Amplify.configure(awsConfig);
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/frontend/src/services/aiApi.ts
+++ b/frontend/src/services/aiApi.ts
@@ -5,6 +5,7 @@ export type ConversationType = 'TASK_CREATION' | 'STUDY_PLAN' | 'HABIT_SUGGESTIO
 export interface AiChatRequest {
     message: string;
     newConversation?: boolean;
+    userTimezone?: string;
 }
 
 export interface AiChatResponse {
@@ -12,6 +13,7 @@ export interface AiChatResponse {
     aiMessage: string;
     conversationType: ConversationType;
     tasksCreated: number;
+    habitsCreated: number;
     createdAt: string;
 }
 

--- a/frontend/src/services/aiApi.ts
+++ b/frontend/src/services/aiApi.ts
@@ -1,0 +1,42 @@
+import api from './api';
+
+export type ConversationType = 'TASK_CREATION' | 'STUDY_PLAN' | 'HABIT_SUGGESTION' | 'GENERAL_CHAT';
+
+export interface AiChatRequest {
+    message: string;
+    newConversation?: boolean;
+}
+
+export interface AiChatResponse {
+    conversationId: number;
+    aiMessage: string;
+    conversationType: ConversationType;
+    tasksCreated: number;
+    createdAt: string;
+}
+
+export interface AiConversationHistoryItem {
+    conversationId: number;
+    userMessage: string;
+    aiResponse: string;
+    conversationType: ConversationType;
+    tasksCreated: number;
+    createdAt: string;
+}
+
+export const aiApi = {
+    sendMessage: async (request: AiChatRequest): Promise<AiChatResponse> => {
+        const response = await api.post<AiChatResponse>('/ai/chat', request);
+        return response.data;
+    },
+
+    getDailyBriefing: async (): Promise<AiChatResponse> => {
+        const response = await api.get<AiChatResponse>('/ai/briefing');
+        return response.data;
+    },
+
+    getHistory: async (): Promise<AiConversationHistoryItem[]> => {
+        const response = await api.get<AiConversationHistoryItem[]>('/ai/history');
+        return response.data;
+    },
+};


### PR DESCRIPTION
Closes #20

## What's in this PR

Full AI chat integration powered by OpenAI with an agentic tool-call loop, plus a series of bug fixes and UX improvements made during end-to-end testing.

## Features delivered

- **`POST /ai/chat`** — Accepts user messages, runs an agentic loop (up to 5 tool iterations), and returns the AI's response along with metadata (`conversationType`, `tasksCreated`, `habitsCreated`)
- **`GET /ai/briefing`** — Daily briefing summarising due tasks, pending habits, and a motivational note
- **`GET /ai/history`** — Full conversation history per user
- **AI tools** — `get_tasks`, `get_habits`, `get_user_stats`, `create_task`, `update_task`, `delete_task`, `create_habit`, `update_habit`, `delete_habit`
- **AI Chat UI** — `AIChat` component with message history, typing indicator, daily briefing button, and task suggestion cards

## Bug fixes & improvements

| Fix | Detail |
|---|---|
| Serialization of `Instant` | `ObjectMapper.findAndRegisterModules()` registers `JavaTimeModule` from the transitive Jackson 2.x dependency so `Instant`/`LocalDate` fields serialize correctly as ISO strings |
| Timezone-aware due dates | Frontend sends `userTimezone` (IANA, e.g. `Asia/Jerusalem`) with every message; system prompt exposes local time + UTC offset; AI sends due dates as local ISO-8601 with offset (e.g. `2026-05-09T22:00:00+03:00`); backend converts via `OffsetDateTime.parse().toInstant()` |
| Removed `@Future` on `dueDate` | The AI loop introduces a multi-second delay between the user specifying a time and the server receiving the request, causing near-future times to fail validation; AI enforces "must be future" via the system prompt instead |
| AI confirmation before mutations | System prompt requires the AI to describe the intended action in plain language and wait for explicit user approval before calling any create/update/delete tool |
| Blank history turns | `appendHistory` now skips turns where `aiResponse` is blank (from earlier failed responses) — empty assistant messages cause OpenAI to reject the entire request |
| Habit list refresh | `habitsCreated` added to `AiChatResponse`; frontend refreshes the habit list and shows a toast when the AI creates habits, matching the existing task refresh behaviour |
| Due date in `AddTaskModal` | Added `datetime-local` input to the manual task creation form; converts browser local time to UTC ISO string on submit |
| Model name | Changed to `gpt-4.1-mini` in both dev and prod configs (course-provided model with correct API access) |

## Test plan

- [ ] Send a chat message and confirm AI responds
- [ ] Ask AI to create a task with a due date — verify confirmation prompt appears, task is created after approval, task list refreshes
- [ ] Ask AI to create a habit — verify habit list refreshes and toast appears
- [ ] Ask AI to delete a task — verify confirmation is requested first
- [ ] Send a message with a local time (e.g. "due tonight at 10pm") — verify the stored UTC due date matches the correct conversion
- [ ] Check that conversation history is included in follow-up messages
- [ ] Verify daily briefing endpoint returns a summary

🤖 Generated with [Claude Code](https://claude.ai/claude-code)